### PR TITLE
Feature: Disable proximity sensor

### DIFF
--- a/app/src/main/java/com/versobit/kmark/xhangouts/Config.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/Config.java
@@ -53,6 +53,7 @@ public final class Config {
     public boolean attachAnytime = true;
     public boolean hideCallButtons = false;
     public boolean sendLock = false;
+    public boolean disableProximity = false;
     public Setting.AppColor appColor = Setting.AppColor.GOOGLE_GREEN;
     public boolean debug = false;
 
@@ -119,6 +120,9 @@ public final class Config {
                     continue;
                 case UI_SEND_LOCK:
                     sendLock = prefs.getInt(SettingsProvider.QUERY_ALL_VALUE) == SettingsProvider.TRUE;
+                    continue;
+                case UI_DISABLE_PROXIMITY:
+                    disableProximity = prefs.getInt(SettingsProvider.QUERY_ALL_VALUE) == SettingsProvider.TRUE;
                     continue;
                 case UI_APP_COLOR:
                     appColor = Setting.AppColor.fromInt(prefs.getInt(SettingsProvider.QUERY_ALL_VALUE));

--- a/app/src/main/java/com/versobit/kmark/xhangouts/Setting.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/Setting.java
@@ -43,6 +43,7 @@ public enum Setting {
     UI_ATTACH_ANYTIME,
     UI_HIDE_CALL_BUTTONS,
     UI_SEND_LOCK,
+    UI_DISABLE_PROXIMITY,
     UI_APP_COLOR,
     ABOUT_VERSION,
     DEBUG;

--- a/app/src/main/java/com/versobit/kmark/xhangouts/XHangouts.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/XHangouts.java
@@ -31,6 +31,7 @@ import com.versobit.kmark.xhangouts.mods.UiColorize;
 import com.versobit.kmark.xhangouts.mods.UiEnterKey;
 import com.versobit.kmark.xhangouts.mods.UiQuickSettings;
 import com.versobit.kmark.xhangouts.mods.UiSendLock;
+import com.versobit.kmark.xhangouts.mods.UiDisableProximity;
 
 import de.robv.android.xposed.IXposedHookInitPackageResources;
 import de.robv.android.xposed.IXposedHookLoadPackage;
@@ -76,6 +77,7 @@ public final class XHangouts implements IXposedHookZygoteInit,
             new UiColorize(config),
             new UiQuickSettings(config),
             new UiSendLock(config)
+            new UiDisableProximity(config)
     };
 
     @Override

--- a/app/src/main/java/com/versobit/kmark/xhangouts/XHangouts.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/XHangouts.java
@@ -76,7 +76,7 @@ public final class XHangouts implements IXposedHookZygoteInit,
             new UiCallButtons(config),
             new UiColorize(config),
             new UiQuickSettings(config),
-            new UiSendLock(config)
+            new UiSendLock(config),
             new UiDisableProximity(config)
     };
 

--- a/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
@@ -19,14 +19,6 @@
 
 package com.versobit.kmark.xhangouts.mods;
 
-// import android.content.Context;
-// import android.text.InputType;
-// import android.util.AttributeSet;
-// import android.view.KeyEvent;
-// import android.view.inputmethod.EditorInfo;
-// import android.widget.EditText;
-// import android.widget.TextView;
-
 import com.versobit.kmark.xhangouts.Module;
 import com.versobit.kmark.xhangouts.Config;
 import com.versobit.kmark.xhangouts.Setting;
@@ -69,12 +61,10 @@ public final class UiDisableProximity extends Module {
             if(!config.disableProximity) {
                 return;
             }
-            debug(String.valueOf(param.args[0]));
 
             int device_type = (int) param.args[0];
 
             if(device_type == 8) {
-                debug(LOG_SET_RESULT);
                 param.setResult(null);
             }
             return;

--- a/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Kevin Mark
+ * Copyright (C) 2015 Kevin Mark
  *
  * This file is part of XHangouts.
  *
@@ -21,7 +21,8 @@ package com.versobit.kmark.xhangouts.mods;
 
 import com.versobit.kmark.xhangouts.Module;
 import com.versobit.kmark.xhangouts.Config;
-import com.versobit.kmark.xhangouts.Setting;
+
+import android.hardware.Sensor;
 
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.callbacks.IXUnhook;
@@ -33,12 +34,10 @@ public final class UiDisableProximity extends Module {
 
     private static final String ANDROID_HARDWARE_SENSORMANAGER = "android.hardware.SensorManager";
     private static final String ANDROID_HARDWARE_SENSORMANAGER_DEFAULT = "getDefaultSensor";
-    private static final String LOG_SET_RESULT = "set result";
 
     public UiDisableProximity(Config config) {
         super(UiDisableProximity.class.getSimpleName(), config);
     }
-
 
     @Override
     public IXUnhook[] hook(ClassLoader loader) {
@@ -52,6 +51,7 @@ public final class UiDisableProximity extends Module {
     private final XC_MethodHook getDefaultSensor = new XC_MethodHook() {
         @Override
         protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+
             if(!config.modEnabled) {
                 return;
             }
@@ -62,9 +62,9 @@ public final class UiDisableProximity extends Module {
                 return;
             }
 
-            int device_type = (int) param.args[0];
+            int sensorType = (int) param.args[0];
 
-            if(device_type == 8) {
+            if(sensorType == Sensor.TYPE_PROXIMITY) {
                 param.setResult(null);
             }
             return;

--- a/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014-2015 Kevin Mark
+ *
+ * This file is part of XHangouts.
+ *
+ * XHangouts is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * XHangouts is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with XHangouts.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.versobit.kmark.xhangouts.mods;
+
+// import android.content.Context;
+// import android.text.InputType;
+// import android.util.AttributeSet;
+// import android.view.KeyEvent;
+// import android.view.inputmethod.EditorInfo;
+// import android.widget.EditText;
+// import android.widget.TextView;
+
+import com.versobit.kmark.xhangouts.Module;
+import com.versobit.kmark.xhangouts.Config;
+import com.versobit.kmark.xhangouts.Setting;
+
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.callbacks.IXUnhook;
+
+import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
+import static de.robv.android.xposed.XposedHelpers.findClass;
+
+public final class UiDisableProximity extends Module {
+
+    private static final String ANDROID_HARDWARE_SENSORMANAGER = "android.hardware.SensorManager";
+    private static final String ANDROID_HARDWARE_SENSORMANAGER_DEFAULT = "getDefaultSensor";
+
+    public UiDisableProximity(Config config) {
+        super(UiDisableProximity.class.getSimpleName(), config);
+    }
+
+
+    @Override
+    public IXUnhook[] hook(ClassLoader loader) {
+        Class SensorManagerClass = findClass(ANDROID_HARDWARE_SENSORMANAGER, loader);
+
+        return new IXUnhook[] {
+                findAndHookMethod(SensorManagerClass, ANDROID_HARDWARE_SENSORMANAGER_DEFAULT, int.class, getDefaultSensor)
+        };
+    }
+
+    private final XC_MethodHook getDefaultSensor = new XC_MethodHook() {
+        @Override
+        protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+            if(!config.modEnabled) {
+                return;
+            }
+
+            debug(String.valueOf(config.disableProximity));
+
+            if(!config.disableProximity) {
+                return;
+            }
+
+            //if param[0] == 8 then make the return value null
+
+        }
+    };
+
+}

--- a/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
+++ b/app/src/main/java/com/versobit/kmark/xhangouts/mods/UiDisableProximity.java
@@ -41,6 +41,7 @@ public final class UiDisableProximity extends Module {
 
     private static final String ANDROID_HARDWARE_SENSORMANAGER = "android.hardware.SensorManager";
     private static final String ANDROID_HARDWARE_SENSORMANAGER_DEFAULT = "getDefaultSensor";
+    private static final String LOG_SET_RESULT = "set result";
 
     public UiDisableProximity(Config config) {
         super(UiDisableProximity.class.getSimpleName(), config);
@@ -58,7 +59,7 @@ public final class UiDisableProximity extends Module {
 
     private final XC_MethodHook getDefaultSensor = new XC_MethodHook() {
         @Override
-        protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+        protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
             if(!config.modEnabled) {
                 return;
             }
@@ -68,9 +69,15 @@ public final class UiDisableProximity extends Module {
             if(!config.disableProximity) {
                 return;
             }
+            debug(String.valueOf(param.args[0]));
 
-            //if param[0] == 8 then make the return value null
+            int device_type = (int) param.args[0];
 
+            if(device_type == 8) {
+                debug(LOG_SET_RESULT);
+                param.setResult(null);
+            }
+            return;
         }
     };
 

--- a/app/src/main/res/values/strings_activity_settings.xml
+++ b/app/src/main/res/values/strings_activity_settings.xml
@@ -91,6 +91,9 @@
     <string name="pref_title_ui_send_lock">Send &amp; lock</string>
     <string name="pref_desc_ui_send_lock">Long press the send button to send and lock the screen. Hangouts will ask for root.</string>
 
+    <string name="pref_title_ui_disable_proximity">Disable proximity sensor</string>
+    <string name="pref_desc_ui_disable_proximity">Proximity sensor will no longer be used.</string>
+
     <string name="pref_title_ui_app_color">App color</string>
     <string-array name="pref_ui_app_color_titles">
         <item>Amber</item>

--- a/app/src/main/res/xml/pref_ui.xml
+++ b/app/src/main/res/xml/pref_ui.xml
@@ -50,6 +50,13 @@
         android:summary="@string/pref_desc_ui_send_lock"
         android:defaultValue="false" />
 
+    <CheckBoxPreference
+        android:dependency="mod_enabled"
+        android:key="ui_disable_proximity"
+        android:title="@string/pref_title_ui_disable_proximity"
+        android:summary="@string/pref_desc_ui_disable_proximity"
+        android:defaultValue="false" />
+
     <Preference
         android:dependency="mod_enabled"
         android:key="ui_app_color"


### PR DESCRIPTION
This fork adds an option to disable hangouts' access to the phones proximity sensor. It does this by hooking onto `SensorManager.getDefaultSensor` and forcing a null return value when the params ask for one.

The reason someone would want this is because on some phones the proximity sensor is a flashing red light right above the screen. It flashes just fast enough to be very distracting. Although there are places a proximity sensor would be used, there is a bug in hangouts that causes the sensor to be initialized in text chats, where it does nothing ([bug report here](https://productforums.google.com/forum/#!topic/hangouts/4_Lkg9e4Nb0))
